### PR TITLE
version 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Now you can :
 * `./vendor/bin/robo wp:init`
 * `./vendor/bin/robo wp:db-create`
 * `./vendor/bin/robo wp:core:install`
-* `./vendor/bin/robo wp:plugin-update [<plugin-name>] [--all]`
 * `./vendor/bin/robo feature:start <feature-name>`
 * `./vendor/bin/robo feature:finish <feature-name>`
 * `./vendor/bin/robo hotfix:start [--semversion [SEMVERSION]]`

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -222,47 +222,6 @@ class RoboFile extends \Globalis\Robo\Tasks
             ->execute();
     }
 
-    public function wpPluginUpdate($name = null, $opts = ['all' => false])
-    {
-        if (null === $name && false === $opts['all']) {
-            throw new Exception('Provide a plugin name, or use --all');
-        }
-
-        @ini_set('memory_limit', '1G');
-
-        $composer        = \Composer\Factory::create(new \Composer\IO\NullIO(), null, true);
-        $package         = $composer->getPackage();
-        $repositories    = $composer->getRepositoryManager()->getRepositories();
-
-        $pool = new \Composer\DependencyResolver\Pool();
-        $pool->addRepository(new \Composer\Repository\CompositeRepository($repositories));
-        $versionSelector = new \Composer\Package\Version\VersionSelector($pool);
-
-        $requires = array_merge(
-            $composer->getPackage()->getRequires(),
-            $composer->getPackage()->getDevRequires()
-        );
-
-        $latests = [];
-        foreach ($requires as $packageName => $link) {
-            $packageNameParts = explode('/', $packageName);
-            if (isset($packageNameParts[1])) {
-                if (true === $opts['all'] || $name === $packageNameParts[1]) {
-                    $dependency = $versionSelector->findBestCandidate($packageName);
-                    if ('wordpress-plugin' == $dependency->getType()) {
-                        $latests[$packageName] = $dependency->getPrettyVersion();
-                    }
-                }
-            }
-        }
-
-        $cmd = $this->taskComposer('require');
-        foreach ($latests as $packageName => $packageVersion) {
-            $cmd = $cmd->arg($packageName . ':' . $packageVersion, false);
-        }
-        $cmd->run();
-    }
-
     /**
      * Start a new feature
      *

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.6",
         "composer/installers": "^1.4",
-        "johnpbloch/wordpress": "4.8.2",
+        "johnpbloch/wordpress": "4.8.3",
         "globalis/wp-cubi-helpers": "^0.1.6",
         "globalis/wpg-wp-cli-phar" : "^1.3.0",
         "globalis/wpg-local-config" : "^0.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "suggest": {
         "roots/soil": "^3.7.3",
-        "wpackagist-plugin/user-switching": "^1.1.0",
+        "wpackagist-plugin/user-switching": "^1.2.0",
         "wpackagist-plugin/autodescription": "^2.9.4"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=5.6",
         "composer/installers": "^1.4",
         "johnpbloch/wordpress": "4.8.2",
-        "globalis/wp-cubi-helpers": "^0.1.5",
+        "globalis/wp-cubi-helpers": "^0.1.6",
         "globalis/wpg-wp-cli-phar" : "^1.3.0",
         "globalis/wpg-local-config" : "^0.1",
         "globalis/wpg-uploads-path" : "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=5.6",
         "composer/installers": "^1.4",
         "johnpbloch/wordpress": "4.8.2",
-        "globalis/wp-cubi-helpers": "^0.1.4",
+        "globalis/wp-cubi-helpers": "^0.1.5",
         "globalis/wpg-wp-cli-phar" : "^1.3.0",
         "globalis/wpg-local-config" : "^0.1",
         "globalis/wpg-uploads-path" : "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer/installers": "^1.4",
         "johnpbloch/wordpress": "4.8.3",
         "globalis/wp-cubi-helpers": "^0.1.6",
-        "globalis/wpg-wp-cli-phar" : "^1.3.0",
+        "globalis/wpg-wp-cli-phar" : "^1.4.0",
         "globalis/wpg-local-config" : "^0.1",
         "globalis/wpg-uploads-path" : "^0.3",
         "globalis/wpg-disallow-indexing" : "^0.5.1",
@@ -39,7 +39,7 @@
         "globalis/wpg-environment-info" : "^0.3.1",
         "globalis/wpg-security" : "^0.2",
         "roots/wp-password-bcrypt": "^1.0",
-        "wpackagist-plugin/query-monitor": "^2.14.0",
+        "wpackagist-plugin/query-monitor": "^2.16.1",
         "wpackagist-plugin/wp-crontrol": "^1.5",
         "soberwp/intervention": "^1.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -425,16 +425,16 @@
         },
         {
             "name": "globalis/wpg-wp-cli-phar",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-globalis-tools/wpg-wp-cli-phar.git",
-                "reference": "18c8007ef1cdcf0b51514beffc27ce370cb2dec3"
+                "reference": "6981bbb69ba5c4187124fa1285dd595a380154a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-globalis-tools/wpg-wp-cli-phar/zipball/18c8007ef1cdcf0b51514beffc27ce370cb2dec3",
-                "reference": "18c8007ef1cdcf0b51514beffc27ce370cb2dec3",
+                "url": "https://api.github.com/repos/wp-globalis-tools/wpg-wp-cli-phar/zipball/6981bbb69ba5c4187124fa1285dd595a380154a9",
+                "reference": "6981bbb69ba5c4187124fa1285dd595a380154a9",
                 "shasum": ""
             },
             "bin": [
@@ -460,7 +460,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-08-08 16:40:06"
+            "time": "2017-10-17 14:00:06"
         },
         {
             "name": "johnpbloch/wordpress",
@@ -698,16 +698,16 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "2.14.0",
+            "version": "2.16.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/2.14.0"
+                "reference": "tags/2.16.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.2.14.0.zip",
-                "reference": "tags/2.14.0",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.2.16.1.zip",
+                "reference": null,
                 "shasum": null
             },
             "require": {
@@ -999,22 +999,21 @@
         },
         {
             "name": "consolidation/annotated-command",
-            "version": "2.7.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "5e22a86f53ab1417a6002234fe205e69645326b8"
+                "reference": "7f94009d732922d61408536f9228aca8f22e9135"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/5e22a86f53ab1417a6002234fe205e69645326b8",
-                "reference": "5e22a86f53ab1417a6002234fe205e69645326b8",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/7f94009d732922d61408536f9228aca8f22e9135",
+                "reference": "7f94009d732922d61408536f9228aca8f22e9135",
                 "shasum": ""
             },
             "require": {
-                "consolidation/output-formatters": "^3.1.10",
+                "consolidation/output-formatters": "^3.1.12",
                 "php": ">=5.4.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "psr/log": "^1",
                 "symfony/console": "^2.8|~3",
                 "symfony/event-dispatcher": "^2.5|^3",
@@ -1047,20 +1046,20 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2017-09-18 22:52:16"
+            "time": "2017-10-17 01:48:51"
         },
         {
             "name": "consolidation/config",
-            "version": "1.0.2",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/config.git",
-                "reference": "bcff5f4057c6ece20794d58dfc9e56919e2b33b7"
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/config/zipball/bcff5f4057c6ece20794d58dfc9e56919e2b33b7",
-                "reference": "bcff5f4057c6ece20794d58dfc9e56919e2b33b7",
+                "url": "https://api.github.com/repos/consolidation/config/zipball/b59a3b9ea750c21397f26a68fd2e04d9580af42e",
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e",
                 "shasum": ""
             },
             "require": {
@@ -1096,7 +1095,7 @@
                 }
             ],
             "description": "Provide configuration services for a commandline tool.",
-            "time": "2017-09-16 23:24:55"
+            "time": "2017-10-25 05:50:10"
         },
         {
             "name": "consolidation/log",
@@ -1147,16 +1146,16 @@
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.11",
+            "version": "3.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "3a1160440819269e6d8d9c11db67129384b8fb35"
+                "reference": "88ef346a1cefb92aab8b57a3214a6d5fc63f5d2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/3a1160440819269e6d8d9c11db67129384b8fb35",
-                "reference": "3a1160440819269e6d8d9c11db67129384b8fb35",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/88ef346a1cefb92aab8b57a3214a6d5fc63f5d2a",
+                "reference": "88ef346a1cefb92aab8b57a3214a6d5fc63f5d2a",
                 "shasum": ""
             },
             "require": {
@@ -1192,24 +1191,24 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2017-08-17 22:11:07"
+            "time": "2017-10-12 19:38:03"
         },
         {
             "name": "consolidation/robo",
-            "version": "1.1.3",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/Robo.git",
-                "reference": "21370cc6fea83729ab6d903f8f382389b14ae90c"
+                "reference": "aea695cebff81d54ed6daf14894738d5dac1c15c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/21370cc6fea83729ab6d903f8f382389b14ae90c",
-                "reference": "21370cc6fea83729ab6d903f8f382389b14ae90c",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/aea695cebff81d54ed6daf14894738d5dac1c15c",
+                "reference": "aea695cebff81d54ed6daf14894738d5dac1c15c",
                 "shasum": ""
             },
             "require": {
-                "consolidation/annotated-command": "^2.2",
+                "consolidation/annotated-command": "^2.8.1",
                 "consolidation/config": "^1.0.1",
                 "consolidation/log": "~1",
                 "consolidation/output-formatters": "^3.1.5",
@@ -1229,7 +1228,7 @@
                 "codeception/base": "^2.2.6",
                 "codeception/verify": "^0.3.2",
                 "henrikbjorn/lurker": "~1",
-                "natxet/cssmin": "~3",
+                "natxet/cssmin": "3.0.4",
                 "patchwork/jsqueeze": "~2",
                 "pear/archive_tar": "^1.4.2",
                 "phpunit/php-code-coverage": "~2|~4",
@@ -1271,7 +1270,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2017-09-23 15:53:19"
+            "time": "2017-10-25 20:41:21"
         },
         {
             "name": "container-interop/container-interop",
@@ -1411,16 +1410,16 @@
         },
         {
             "name": "grasmash/yaml-expander",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grasmash/yaml-expander.git",
-                "reference": "720c54b2c99b80d5d696714b6826183d34edce93"
+                "reference": "9ec59ccc7a630eb2637639e8214e70d27675456b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grasmash/yaml-expander/zipball/720c54b2c99b80d5d696714b6826183d34edce93",
-                "reference": "720c54b2c99b80d5d696714b6826183d34edce93",
+                "url": "https://api.github.com/repos/grasmash/yaml-expander/zipball/9ec59ccc7a630eb2637639e8214e70d27675456b",
+                "reference": "9ec59ccc7a630eb2637639e8214e70d27675456b",
                 "shasum": ""
             },
             "require": {
@@ -1454,20 +1453,20 @@
                 }
             ],
             "description": "Expands internal property references in a yaml file.",
-            "time": "2017-08-01 16:15:05"
+            "time": "2017-09-26 16:57:45"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.2.1",
+            "version": "5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "429be236f296ca249d61c65649cdf2652f4a5e80"
+                "reference": "d283e11b6e14c6f4664cf080415c4341293e5bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/429be236f296ca249d61c65649cdf2652f4a5e80",
-                "reference": "429be236f296ca249d61c65649cdf2652f4a5e80",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/d283e11b6e14c6f4664cf080415c4341293e5bbd",
+                "reference": "d283e11b6e14c6f4664cf080415c4341293e5bbd",
                 "shasum": ""
             },
             "require": {
@@ -1476,7 +1475,6 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.1",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpdocumentor/phpdocumentor": "^2.7",
                 "phpunit/phpunit": "^4.8.22"
             },
             "bin": [
@@ -1521,7 +1519,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2017-05-16 21:06:09"
+            "time": "2017-10-21 13:15:38"
         },
         {
             "name": "league/container",
@@ -1587,152 +1585,6 @@
                 "service"
             ],
             "time": "2017-05-10 09:20:27"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2017-09-11 18:02:19"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30 18:51:59"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-07-14 14:27:02"
         },
         {
             "name": "psr/container",
@@ -2100,16 +1952,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf"
+                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf",
-                "reference": "a1e1b01293a090cb9ae2ddd221a3251a4a7e4abf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/116bc56e45a8e5572e51eb43ab58c769a352366c",
+                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c",
                 "shasum": ""
             },
             "require": {
@@ -2164,20 +2016,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-06 16:40:18"
+            "time": "2017-10-02 06:42:24"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "8beb24eec70b345c313640962df933499373a944"
+                "reference": "eb95d9ce8f18dcc1b3dfff00cb624c402be78ffd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/8beb24eec70b345c313640962df933499373a944",
-                "reference": "8beb24eec70b345c313640962df933499373a944",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/eb95d9ce8f18dcc1b3dfff00cb624c402be78ffd",
+                "reference": "eb95d9ce8f18dcc1b3dfff00cb624c402be78ffd",
                 "shasum": ""
             },
             "require": {
@@ -2220,20 +2072,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-01 13:23:39"
+            "time": "2017-10-02 06:42:24"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485"
+                "reference": "d7ba037e4b8221956ab1e221c73c9e27e05dd423"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/54ca9520a00386f83bca145819ad3b619aaa2485",
-                "reference": "54ca9520a00386f83bca145819ad3b619aaa2485",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d7ba037e4b8221956ab1e221c73c9e27e05dd423",
+                "reference": "d7ba037e4b8221956ab1e221c73c9e27e05dd423",
                 "shasum": ""
             },
             "require": {
@@ -2283,20 +2135,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-10-02 06:42:24"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b32a0e5f928d0fa3d1dd03c78d020777e50c10cb"
+                "reference": "90bc45abf02ae6b7deb43895c1052cb0038506f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b32a0e5f928d0fa3d1dd03c78d020777e50c10cb",
-                "reference": "b32a0e5f928d0fa3d1dd03c78d020777e50c10cb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/90bc45abf02ae6b7deb43895c1052cb0038506f1",
+                "reference": "90bc45abf02ae6b7deb43895c1052cb0038506f1",
                 "shasum": ""
             },
             "require": {
@@ -2332,20 +2184,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-10-03 13:33:10"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "b2260dbc80f3c4198f903215f91a1ac7fe9fe09e"
+                "reference": "773e19a491d97926f236942484cb541560ce862d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/b2260dbc80f3c4198f903215f91a1ac7fe9fe09e",
-                "reference": "b2260dbc80f3c4198f903215f91a1ac7fe9fe09e",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/773e19a491d97926f236942484cb541560ce862d",
+                "reference": "773e19a491d97926f236942484cb541560ce862d",
                 "shasum": ""
             },
             "require": {
@@ -2381,20 +2233,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-10-02 06:42:24"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -2406,7 +2258,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -2440,20 +2292,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14 15:44:48"
+            "time": "2017-10-11 12:05:26"
         },
         {
             "name": "symfony/process",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0"
+                "reference": "fdf89e57a723a29baf536e288d6e232c059697b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
-                "reference": "b7666e9b438027a1ea0e1ee813ec5042d5d7f6f0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/fdf89e57a723a29baf536e288d6e232c059697b1",
+                "reference": "fdf89e57a723a29baf536e288d6e232c059697b1",
                 "shasum": ""
             },
             "require": {
@@ -2489,20 +2341,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
+            "time": "2017-10-02 06:42:24"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
+                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
-                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
+                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
                 "shasum": ""
             },
             "require": {
@@ -2544,57 +2396,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-29 21:54:42"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2017-10-05 14:43:42"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "87c4f87111c4a906cee50acf77ef8dd6",
-    "content-hash": "02bf62790a3582208f2f9b1b491613a1",
+    "hash": "db521dc963164a1b3965102abea3254f",
+    "content-hash": "0adcf522eaa229201160ebdaa3ae1d34",
     "packages": [
         {
             "name": "composer/installers",
@@ -126,16 +126,16 @@
         },
         {
             "name": "globalis/wp-cubi-helpers",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-globalis-tools/wp-cubi-helpers.git",
-                "reference": "bfd001a0dac0b6dd1cfc5ed0155a361499148501"
+                "reference": "68d42f621fe573b2e1b6efcc87a0621a195e9f8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-globalis-tools/wp-cubi-helpers/zipball/bfd001a0dac0b6dd1cfc5ed0155a361499148501",
-                "reference": "bfd001a0dac0b6dd1cfc5ed0155a361499148501",
+                "url": "https://api.github.com/repos/wp-globalis-tools/wp-cubi-helpers/zipball/68d42f621fe573b2e1b6efcc87a0621a195e9f8c",
+                "reference": "68d42f621fe573b2e1b6efcc87a0621a195e9f8c",
                 "shasum": ""
             },
             "require-dev": {
@@ -178,7 +178,7 @@
                 "wp",
                 "wp-cubi"
             ],
-            "time": "2017-08-18 09:55:35"
+            "time": "2017-09-25 10:12:25"
         },
         {
             "name": "globalis/wpg-disallow-indexing",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6c85c33235c6b09e220f370d68159d80",
-    "content-hash": "14e5c620f986e245dd3afce74bc6f1b6",
+    "hash": "cc0f02703114ab77efedf027427b5d8c",
+    "content-hash": "aba0433b5a45cf6cd80a3d7432e2bbfd",
     "packages": [
         {
             "name": "composer/installers",
@@ -464,20 +464,20 @@
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "4.8.2",
+            "version": "4.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "d500aae1793990e4874cf794b6cf88ce60a38918"
+                "reference": "d5bc0df53dd6e6e43082f47ccee89aab2049bc23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/d500aae1793990e4874cf794b6cf88ce60a38918",
-                "reference": "d500aae1793990e4874cf794b6cf88ce60a38918",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/d5bc0df53dd6e6e43082f47ccee89aab2049bc23",
+                "reference": "d5bc0df53dd6e6e43082f47ccee89aab2049bc23",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "4.8.2",
+                "johnpbloch/wordpress-core": "4.8.3",
                 "johnpbloch/wordpress-core-installer": "^1.0",
                 "php": ">=5.3.2"
             },
@@ -499,27 +499,27 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2017-09-19 22:27:16"
+            "time": "2017-10-31 16:40:07"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "4.8.2",
+            "version": "4.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "706faa0d7b6b57a25d4acd18331dd71dfa6b01cf"
+                "reference": "949e279f9752b458d70288636a77d2b8f66801f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/706faa0d7b6b57a25d4acd18331dd71dfa6b01cf",
-                "reference": "706faa0d7b6b57a25d4acd18331dd71dfa6b01cf",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/949e279f9752b458d70288636a77d2b8f66801f6",
+                "reference": "949e279f9752b458d70288636a77d2b8f66801f6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "4.8.2"
+                "wordpress/core-implementation": "4.8.3"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -539,7 +539,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2017-09-19 22:27:11"
+            "time": "2017-10-31 16:39:59"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "db521dc963164a1b3965102abea3254f",
-    "content-hash": "0adcf522eaa229201160ebdaa3ae1d34",
+    "hash": "6c85c33235c6b09e220f370d68159d80",
+    "content-hash": "14e5c620f986e245dd3afce74bc6f1b6",
     "packages": [
         {
             "name": "composer/installers",
@@ -126,16 +126,16 @@
         },
         {
             "name": "globalis/wp-cubi-helpers",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-globalis-tools/wp-cubi-helpers.git",
-                "reference": "68d42f621fe573b2e1b6efcc87a0621a195e9f8c"
+                "reference": "cb4ab6ec06c2ca6960548e06d5720691b7c5b1ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-globalis-tools/wp-cubi-helpers/zipball/68d42f621fe573b2e1b6efcc87a0621a195e9f8c",
-                "reference": "68d42f621fe573b2e1b6efcc87a0621a195e9f8c",
+                "url": "https://api.github.com/repos/wp-globalis-tools/wp-cubi-helpers/zipball/cb4ab6ec06c2ca6960548e06d5720691b7c5b1ca",
+                "reference": "cb4ab6ec06c2ca6960548e06d5720691b7c5b1ca",
                 "shasum": ""
             },
             "require-dev": {
@@ -178,7 +178,7 @@
                 "wp",
                 "wp-cubi"
             ],
-            "time": "2017-09-25 10:12:25"
+            "time": "2017-11-02 11:28:37"
         },
         {
             "name": "globalis/wpg-disallow-indexing",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,7 +15,7 @@
   <exclude-pattern>/web/app/mu-modules/*/</exclude-pattern>
 
   <!-- Ignore local files -->
-  <exclude-pattern>/config/vars.php*</exclude-pattern>
+  <exclude-pattern>/config/vars.*</exclude-pattern>
   <exclude-pattern>/config/local.php</exclude-pattern>
   <exclude-pattern>/config/salt-keys.php</exclude-pattern>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,4 +30,7 @@
 
   <!-- Use PSR-2 as a base -->
   <rule ref="PSR2"/>
+
+  <!-- Custom rule: disallow long `array()` syntax, use short `[]` syntax instead -->
+  <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 </ruleset>

--- a/web/app/db.php
+++ b/web/app/db.php
@@ -1,5 +1,5 @@
 <?php
 
 if (file_exists(WP_PLUGIN_DIR . '/query-monitor/wp-content/db.php')) {
-    require_once(WP_PLUGIN_DIR . '/query-monitor/wp-content/db.php');
+    include_once(WP_PLUGIN_DIR . '/query-monitor/wp-content/db.php');
 }

--- a/web/app/mu-modules/bedrock-autoloader.php
+++ b/web/app/mu-modules/bedrock-autoloader.php
@@ -136,7 +136,7 @@ class Autoloader
         $plugins            = array_diff_key(self::$auto_plugins, self::$mu_plugins);
         $rebuild            = !is_array(self::$cache['plugins']);
         self::$activated    = ($rebuild) ? $plugins : array_diff_key($plugins, self::$cache['plugins']);
-        self::$cache        = array('plugins' => $plugins, 'count' => $this->countPlugins());
+        self::$cache        = ['plugins' => $plugins, 'count' => $this->countPlugins()];
 
         update_site_option('bedrock_autoloader', self::$cache);
     }

--- a/web/app/mu-modules/wp-cubi-default-filters.php
+++ b/web/app/mu-modules/wp-cubi-default-filters.php
@@ -33,3 +33,8 @@ add_filter('pre_option_use_smilies', '__return_zero', 10, 1);
  * Disable dashboard browse-happy requests / widget
  */
 add_filter('pre_site_transient_browser_' . md5($_SERVER['HTTP_USER_AGENT']), '__return_true');
+
+/*
+ * Disable 'Try Gutenberg' panel
+ */
+remove_action('try_gutenberg_panel', 'wp_try_gutenberg_panel');

--- a/web/app/mu-modules/wp-cubi-default-filters.php
+++ b/web/app/mu-modules/wp-cubi-default-filters.php
@@ -28,3 +28,8 @@ add_filter('sanitize_file_name', 'remove_accents', 10, 1);
  * Disable conversion of wysiwyg smilies codes to images
  */
 add_filter('pre_option_use_smilies', '__return_zero', 10, 1);
+
+/*
+ * Disable dashboard browse-happy requests / widget
+ */
+add_filter('pre_site_transient_browser_' . md5($_SERVER['HTTP_USER_AGENT']), '__return_true');


### PR DESCRIPTION
- Default filters: Disable dashboard browse-happy requests / widget
- Default filters: Disable 'Try Gutenberg' panel
- Bump WordPress version: 4.8.3
- Bump globalis/wp-cubi-helpers: 0.1.6
- Update composer dependencies (including wp-cli 1.4.0)
- Bump version of suggested packages
- Remove robo command robo wp:plugin-update, because native use of composer is the best way to manage them
- Update phpcs.xml: ignore /config/vars.*
- Coding standards: disallow long 'array()' syntax, use short '[]' syntax instead
- Changing require to include for semantic reasons