### PR TITLE
Configuration: Allow database blank passwords

### DIFF
--- a/.robo/properties.php
+++ b/.robo/properties.php
@@ -21,6 +21,7 @@ return [
         'question' => 'Database password',
         'default' => '',
         'hidden'  => true,
+        'empty' => true,
     ],
     'ENVIRONEMENT' => [
         'question' => 'Environment',


### PR DESCRIPTION
Related to https://github.com/globalis-ms/wp-cubi/issues/47