### PR TITLE
version 0.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - nightly
+    - 7.3
 
 cache:
     directories:

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Built with [Composer](http://getcomposer.org) dependency manager and [Robo](http
 * `./vendor/bin/robo wp:update-timezone`
 * `./vendor/bin/robo feature:start <feature-name>`
 * `./vendor/bin/robo feature:finish <feature-name>`
-* `./vendor/bin/robo hotfix:start [--semversion <version>]`
-* `./vendor/bin/robo hotfix:finish [--semversion <version>]`
-* `./vendor/bin/robo release:start [--semversion <version>]`
-* `./vendor/bin/robo release:finish [--semversion <version>]`
+* `./vendor/bin/robo hotfix:start [--semversion=<version>]`
+* `./vendor/bin/robo hotfix:finish [--semversion=<version>]`
+* `./vendor/bin/robo release:start [--semversion=<version>]`
+* `./vendor/bin/robo release:finish [--semversion=<version>]`
 * `./vendor/bin/robo deploy <environment> <version> [--ignore-assets]`
 * `./vendor/bin/robo deploy:setup <environment>`
 * `./vendor/bin/robo media:dump <environment> [--delete]`

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer/installers": "^1.5.0",
         "johnpbloch/wordpress-core-installer": "^1.0",
         "johnpbloch/wordpress-core": "4.9.9",
-        "globalis/wp-cli-bin" : "^2.0.1",
+        "globalis/wp-cli-bin" : "^2.1.0",
         "globalis/wp-cubi-helpers": "^0.3.3",
         "globalis/wp-cubi-imagemin": "^1.0.3",
         "roots/soil": "^3.7.3",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "johnpbloch/wordpress-core-installer": "^1.0",
         "johnpbloch/wordpress-core": "4.9.9",
         "globalis/wp-cli-bin" : "^2.1.0",
-        "globalis/wp-cubi-helpers": "^0.3.3",
+        "globalis/wp-cubi-helpers": "^0.3.4",
         "globalis/wp-cubi-imagemin": "^1.0.3",
         "roots/soil": "^3.7.3",
         "roots/wp-password-bcrypt": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
         "soberwp/intervention": "^1.2.0",
         "inpsyde/wonolog": "^1.0.2",
         "wpackagist-plugin/query-monitor": "^3.3.3",
-        "wpackagist-plugin/wp-crontrol": "^1.6.2",
-        "wpackagist-plugin/user-switching": "^1.4.1",
-        "wpackagist-plugin/autodescription": "^3.2.2"
+        "wpackagist-plugin/wp-crontrol": "^1.7.0",
+        "wpackagist-plugin/user-switching": "^1.4.2",
+        "wpackagist-plugin/autodescription": "^3.2.4"
     },
     "require-dev": {
         "globalis/wp-cubi-robo" : "^0.1.5",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=7.0",
         "composer/installers": "^1.5.0",
         "johnpbloch/wordpress-core-installer": "^1.0",
-        "johnpbloch/wordpress-core": "4.9.9",
+        "johnpbloch/wordpress-core": "4.9.10",
         "globalis/wp-cli-bin" : "^2.1.0",
         "globalis/wp-cubi-helpers": "^0.3.4",
         "globalis/wp-cubi-imagemin": "^1.0.3",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=7.0",
         "composer/installers": "^1.5.0",
         "johnpbloch/wordpress-core-installer": "^1.0",
-        "johnpbloch/wordpress-core": "4.9.8",
+        "johnpbloch/wordpress-core": "4.9.9",
         "globalis/wp-cli-bin" : "^2.0.1",
         "globalis/wp-cubi-helpers": "^0.3.3",
         "globalis/wp-cubi-imagemin": "^1.0.3",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "roots/wp-password-bcrypt": "^1.0.0",
         "soberwp/intervention": "^1.2.0",
         "inpsyde/wonolog": "^1.0.2",
-        "wpackagist-plugin/query-monitor": "^3.2.2",
+        "wpackagist-plugin/query-monitor": "^3.3.3",
         "wpackagist-plugin/wp-crontrol": "^1.6.2",
         "wpackagist-plugin/user-switching": "^1.4.1",
         "wpackagist-plugin/autodescription": "^3.2.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "77c631fb27a69ffc453ef683f01c2a43",
+    "content-hash": "a20b84ec5223015e5eb4d68296bdb035",
     "packages": [
         {
             "name": "composer/installers",
@@ -336,23 +336,23 @@
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "4.9.8",
+            "version": "4.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "50323f9b91d7689d615b4af02caf9d80584b1cfc"
+                "reference": "3f6081c514707ad25153b9acb90f022cd122d759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/50323f9b91d7689d615b4af02caf9d80584b1cfc",
-                "reference": "50323f9b91d7689d615b4af02caf9d80584b1cfc",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/3f6081c514707ad25153b9acb90f022cd122d759",
+                "reference": "3f6081c514707ad25153b9acb90f022cd122d759",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "4.9.8"
+                "wordpress/core-implementation": "4.9.9"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -372,7 +372,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2018-08-02T21:48:32+00:00"
+            "time": "2018-12-13T03:42:54+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f81655614cddd94f487ea3f2fc8104cc",
+    "content-hash": "c3d4bc3dd20e9f0c6d7a2e02bb29dfbc",
     "packages": [
         {
             "name": "composer/installers",
@@ -336,23 +336,23 @@
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "4.9.9",
+            "version": "4.9.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "3f6081c514707ad25153b9acb90f022cd122d759"
+                "reference": "06dad62aa1ab1ef215034fb07d6aec4a68072313"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/3f6081c514707ad25153b9acb90f022cd122d759",
-                "reference": "3f6081c514707ad25153b9acb90f022cd122d759",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/06dad62aa1ab1ef215034fb07d6aec4a68072313",
+                "reference": "06dad62aa1ab1ef215034fb07d6aec4a68072313",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "4.9.9"
+                "wordpress/core-implementation": "4.9.10"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -372,7 +372,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2018-12-13T03:42:54+00:00"
+            "time": "2019-03-13T01:13:06+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc4b5e5717d5fd9bb689bdfbe8db257e",
+    "content-hash": "f81655614cddd94f487ea3f2fc8104cc",
     "packages": [
         {
             "name": "composer/installers",
@@ -873,15 +873,15 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "3.2.2",
+            "version": "3.3.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.2.2"
+                "reference": "tags/3.3.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.2.2.zip",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.3.3.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2d432e0bb4d33b72ceb15a7c338a17d",
+    "content-hash": "bc4b5e5717d5fd9bb689bdfbe8db257e",
     "packages": [
         {
             "name": "composer/installers",
@@ -167,16 +167,16 @@
         },
         {
             "name": "globalis/wp-cubi-helpers",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/globalis-ms/wp-cubi-helpers.git",
-                "reference": "0822b0416fe8c82b2da23d5b7c8f8f1505cea8be"
+                "reference": "fa1bade50e1db4d06916e724c0393f3a09cc54b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/globalis-ms/wp-cubi-helpers/zipball/0822b0416fe8c82b2da23d5b7c8f8f1505cea8be",
-                "reference": "0822b0416fe8c82b2da23d5b7c8f8f1505cea8be",
+                "url": "https://api.github.com/repos/globalis-ms/wp-cubi-helpers/zipball/fa1bade50e1db4d06916e724c0393f3a09cc54b8",
+                "reference": "fa1bade50e1db4d06916e724c0393f3a09cc54b8",
                 "shasum": ""
             },
             "require": {
@@ -224,7 +224,7 @@
                 "wp",
                 "wp-cubi"
             ],
-            "time": "2019-01-28T15:48:43+00:00"
+            "time": "2019-02-14T18:23:58+00:00"
         },
         {
             "name": "globalis/wp-cubi-imagemin",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a20b84ec5223015e5eb4d68296bdb035",
+    "content-hash": "c2d432e0bb4d33b72ceb15a7c338a17d",
     "packages": [
         {
             "name": "composer/installers",
@@ -128,16 +128,16 @@
         },
         {
             "name": "globalis/wp-cli-bin",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/globalis-ms/wp-cli-bin.git",
-                "reference": "9ebb1cf7a0f86efbcba8f4a3cc13265d320b81e2"
+                "reference": "a27e3bbffc8fbb11b683ee65ebf670c09eed649d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/globalis-ms/wp-cli-bin/zipball/9ebb1cf7a0f86efbcba8f4a3cc13265d320b81e2",
-                "reference": "9ebb1cf7a0f86efbcba8f4a3cc13265d320b81e2",
+                "url": "https://api.github.com/repos/globalis-ms/wp-cli-bin/zipball/a27e3bbffc8fbb11b683ee65ebf670c09eed649d",
+                "reference": "a27e3bbffc8fbb11b683ee65ebf670c09eed649d",
                 "shasum": ""
             },
             "bin": [
@@ -163,7 +163,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2018-08-28T07:31:05+00:00"
+            "time": "2019-02-06T15:20:49+00:00"
         },
         {
             "name": "globalis/wp-cubi-helpers",

--- a/composer.lock
+++ b/composer.lock
@@ -750,16 +750,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "0f1cbaee6b356e72c0e025f9a4e9d76a25bf4793"
+                "reference": "926e3b797e6bb66c0e4d7da7eff3a174f7378bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/0f1cbaee6b356e72c0e025f9a4e9d76a25bf4793",
-                "reference": "0f1cbaee6b356e72c0e025f9a4e9d76a25bf4793",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/926e3b797e6bb66c0e4d7da7eff3a174f7378bcf",
+                "reference": "926e3b797e6bb66c0e4d7da7eff3a174f7378bcf",
                 "shasum": ""
             },
             "require": {
@@ -800,11 +800,11 @@
                 "configuration",
                 "options"
             ],
-            "time": "2019-01-16T09:39:14+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -853,15 +853,15 @@
         },
         {
             "name": "wpackagist-plugin/autodescription",
-            "version": "3.2.2",
+            "version": "3.2.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/autodescription/",
-                "reference": "tags/3.2.2"
+                "reference": "tags/3.2.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/autodescription.3.2.2.zip",
+                "url": "https://downloads.wordpress.org/plugin/autodescription.3.2.4.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -893,15 +893,15 @@
         },
         {
             "name": "wpackagist-plugin/user-switching",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/user-switching/",
-                "reference": "tags/1.4.1"
+                "reference": "tags/1.4.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/user-switching.1.4.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/user-switching.1.4.2.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -913,15 +913,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-crontrol",
-            "version": "1.6.2",
+            "version": "1.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-crontrol/",
-                "reference": "tags/1.6.2"
+                "reference": "tags/1.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.6.2.zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.7.0.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -991,16 +991,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.8.3",
+            "version": "1.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "a6a3b44581398b7135c7baa0557b7c5b10808b47"
+                "reference": "bc364c2480c17941e2135cfc568fa41794392534"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/a6a3b44581398b7135c7baa0557b7c5b10808b47",
-                "reference": "a6a3b44581398b7135c7baa0557b7c5b10808b47",
+                "url": "https://api.github.com/repos/composer/composer/zipball/bc364c2480c17941e2135cfc568fa41794392534",
+                "reference": "bc364c2480c17941e2135cfc568fa41794392534",
                 "shasum": ""
             },
             "require": {
@@ -1067,20 +1067,20 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-01-30T07:31:34+00:00"
+            "time": "2019-02-11T09:52:10+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
                 "shasum": ""
             },
             "require": {
@@ -1129,7 +1129,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30T16:08:34+00:00"
+            "time": "2019-03-19T17:25:45+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -1238,16 +1238,16 @@
         },
         {
             "name": "consolidation/annotated-command",
-            "version": "2.11.2",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "004af26391cd7d1cd04b0ac736dc1324d1b4f572"
+                "reference": "512a2e54c98f3af377589de76c43b24652bcb789"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/004af26391cd7d1cd04b0ac736dc1324d1b4f572",
-                "reference": "004af26391cd7d1cd04b0ac736dc1324d1b4f572",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/512a2e54c98f3af377589de76c43b24652bcb789",
+                "reference": "512a2e54c98f3af377589de76c43b24652bcb789",
                 "shasum": ""
             },
             "require": {
@@ -1330,20 +1330,20 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2019-02-02T02:29:53+00:00"
+            "time": "2019-03-08T16:55:03+00:00"
         },
         {
             "name": "consolidation/config",
-            "version": "1.1.1",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/config.git",
-                "reference": "925231dfff32f05b787e1fddb265e789b939cf4c"
+                "reference": "cac1279bae7efb5c7fb2ca4c3ba4b8eb741a96c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/config/zipball/925231dfff32f05b787e1fddb265e789b939cf4c",
-                "reference": "925231dfff32f05b787e1fddb265e789b939cf4c",
+                "url": "https://api.github.com/repos/consolidation/config/zipball/cac1279bae7efb5c7fb2ca4c3ba4b8eb741a96c1",
+                "reference": "cac1279bae7efb5c7fb2ca4c3ba4b8eb741a96c1",
                 "shasum": ""
             },
             "require": {
@@ -1352,9 +1352,9 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^1",
+                "g1a/composer-test-scenarios": "^3",
+                "php-coveralls/php-coveralls": "^1",
                 "phpunit/phpunit": "^5",
-                "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "2.*",
                 "symfony/console": "^2.5|^3|^4",
                 "symfony/yaml": "^2.8.11|^3|^4"
@@ -1364,6 +1364,33 @@
             },
             "type": "library",
             "extra": {
+                "scenarios": {
+                    "symfony4": {
+                        "require-dev": {
+                            "symfony/console": "^4.0"
+                        },
+                        "config": {
+                            "platform": {
+                                "php": "7.1.3"
+                            }
+                        }
+                    },
+                    "symfony2": {
+                        "require-dev": {
+                            "symfony/console": "^2.8",
+                            "symfony/event-dispatcher": "^2.8",
+                            "phpunit/phpunit": "^4.8.36"
+                        },
+                        "remove": [
+                            "php-coveralls/php-coveralls"
+                        ],
+                        "config": {
+                            "platform": {
+                                "php": "5.4.8"
+                            }
+                        }
+                    }
+                },
                 "branch-alias": {
                     "dev-master": "1.x-dev"
                 }
@@ -1384,7 +1411,7 @@
                 }
             ],
             "description": "Provide configuration services for a commandline tool.",
-            "time": "2018-10-24T17:55:35+00:00"
+            "time": "2019-03-03T19:37:04+00:00"
         },
         {
             "name": "consolidation/log",
@@ -1478,16 +1505,16 @@
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "a942680232094c4a5b21c0b7e54c20cce623ae19"
+                "reference": "0881112642ad9059071f13f397f571035b527cb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/a942680232094c4a5b21c0b7e54c20cce623ae19",
-                "reference": "a942680232094c4a5b21c0b7e54c20cce623ae19",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/0881112642ad9059071f13f397f571035b527cb9",
+                "reference": "0881112642ad9059071f13f397f571035b527cb9",
                 "shasum": ""
             },
             "require": {
@@ -1497,11 +1524,10 @@
                 "symfony/finder": "^2.5|^3|^4"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^2",
+                "g1a/composer-test-scenarios": "^3",
+                "php-coveralls/php-coveralls": "^1",
                 "phpunit/phpunit": "^5.7.27",
-                "satooshi/php-coveralls": "^2",
                 "squizlabs/php_codesniffer": "^2.7",
-                "symfony/console": "3.2.3",
                 "symfony/var-dumper": "^2.8|^3|^4",
                 "victorjonsson/markdowndocs": "^1.3"
             },
@@ -1510,6 +1536,52 @@
             },
             "type": "library",
             "extra": {
+                "scenarios": {
+                    "symfony4": {
+                        "require": {
+                            "symfony/console": "^4.0"
+                        },
+                        "require-dev": {
+                            "phpunit/phpunit": "^6"
+                        },
+                        "config": {
+                            "platform": {
+                                "php": "7.1.3"
+                            }
+                        }
+                    },
+                    "symfony3": {
+                        "require": {
+                            "symfony/console": "^3.4",
+                            "symfony/finder": "^3.4",
+                            "symfony/var-dumper": "^3.4"
+                        },
+                        "config": {
+                            "platform": {
+                                "php": "5.6.32"
+                            }
+                        }
+                    },
+                    "symfony2": {
+                        "require": {
+                            "symfony/console": "^2.8"
+                        },
+                        "require-dev": {
+                            "phpunit/phpunit": "^4.8.36"
+                        },
+                        "remove": [
+                            "php-coveralls/php-coveralls"
+                        ],
+                        "config": {
+                            "platform": {
+                                "php": "5.4.8"
+                            }
+                        },
+                        "scenario-options": {
+                            "create-lockfile": "false"
+                        }
+                    }
+                },
                 "branch-alias": {
                     "dev-master": "3.x-dev"
                 }
@@ -1530,25 +1602,25 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2018-10-19T22:35:38+00:00"
+            "time": "2019-03-14T03:45:44+00:00"
         },
         {
             "name": "consolidation/robo",
-            "version": "1.4.3",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/Robo.git",
-                "reference": "d0b6f516ec940add7abed4f1432d30cca5f8ae0c"
+                "reference": "5c6b3840a45afda1cbffbb3bb1f94dd5f9f83345"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/d0b6f516ec940add7abed4f1432d30cca5f8ae0c",
-                "reference": "d0b6f516ec940add7abed4f1432d30cca5f8ae0c",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/5c6b3840a45afda1cbffbb3bb1f94dd5f9f83345",
+                "reference": "5c6b3840a45afda1cbffbb3bb1f94dd5f9f83345",
                 "shasum": ""
             },
             "require": {
                 "consolidation/annotated-command": "^2.10.2",
-                "consolidation/config": "^1.0.10",
+                "consolidation/config": "^1.2",
                 "consolidation/log": "~1",
                 "consolidation/output-formatters": "^3.1.13",
                 "consolidation/self-update": "^1",
@@ -1574,7 +1646,7 @@
                 "natxet/cssmin": "3.0.4",
                 "nikic/php-parser": "^3.1.5",
                 "patchwork/jsqueeze": "~2",
-                "pear/archive_tar": "^1.4.2",
+                "pear/archive_tar": "^1.4.4",
                 "php-coveralls/php-coveralls": "^1",
                 "phpunit/php-code-coverage": "~2|~4",
                 "squizlabs/php_codesniffer": "^2.8"
@@ -1638,7 +1710,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2019-01-02T21:33:28+00:00"
+            "time": "2019-03-19T18:07:19+00:00"
         },
         {
             "name": "consolidation/self-update",
@@ -2369,16 +2441,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "069bf3f0e8f871a2169a06e43d9f3f03f355e9be"
+                "reference": "71ce77f37af0c5ffb9590e43cc4f70e426945c5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/069bf3f0e8f871a2169a06e43d9f3f03f355e9be",
-                "reference": "069bf3f0e8f871a2169a06e43d9f3f03f355e9be",
+                "url": "https://api.github.com/repos/symfony/console/zipball/71ce77f37af0c5ffb9590e43cc4f70e426945c5e",
+                "reference": "71ce77f37af0c5ffb9590e43cc4f70e426945c5e",
                 "shasum": ""
             },
             "require": {
@@ -2437,20 +2509,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-25T10:42:12+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "667a26c4dd6bc75c67f06bc9bcd015bdecc7cbb8"
+                "reference": "8d8a9e877b3fcdc50ddecf8dcea146059753f782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/667a26c4dd6bc75c67f06bc9bcd015bdecc7cbb8",
-                "reference": "667a26c4dd6bc75c67f06bc9bcd015bdecc7cbb8",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/8d8a9e877b3fcdc50ddecf8dcea146059753f782",
+                "reference": "8d8a9e877b3fcdc50ddecf8dcea146059753f782",
                 "shasum": ""
             },
             "require": {
@@ -2493,20 +2565,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-25T10:19:25+00:00"
+            "time": "2019-02-24T15:45:11+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "ed5be1663fa66623b3a7004d5d51a14c4045399b"
+                "reference": "ec625e2fff7f584eeb91754821807317b2e79236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ed5be1663fa66623b3a7004d5d51a14c4045399b",
-                "reference": "ed5be1663fa66623b3a7004d5d51a14c4045399b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ec625e2fff7f584eeb91754821807317b2e79236",
+                "reference": "ec625e2fff7f584eeb91754821807317b2e79236",
                 "shasum": ""
             },
             "require": {
@@ -2556,20 +2628,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T13:27:11+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b52454ec66fe5082b7a66a491339d1f1da9a5a0d"
+                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b52454ec66fe5082b7a66a491339d1f1da9a5a0d",
-                "reference": "b52454ec66fe5082b7a66a491339d1f1da9a5a0d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/acf99758b1df8e9295e6b85aa69f294565c9fedb",
+                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb",
                 "shasum": ""
             },
             "require": {
@@ -2606,20 +2678,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T13:27:11+00:00"
+            "time": "2019-02-04T21:34:32+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "7c0c627220308928e958a87c293108e5891cde1d"
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/7c0c627220308928e958a87c293108e5891cde1d",
-                "reference": "7c0c627220308928e958a87c293108e5891cde1d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fcdde4aa38f48190ce70d782c166f23930084f9b",
+                "reference": "fcdde4aa38f48190ce70d782c166f23930084f9b",
                 "shasum": ""
             },
             "require": {
@@ -2655,7 +2727,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T13:43:35+00:00"
+            "time": "2019-02-22T14:44:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2776,16 +2848,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.22",
+            "version": "v3.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ba11776e9e6c15ad5759a07bffb15899bac75c2d"
+                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ba11776e9e6c15ad5759a07bffb15899bac75c2d",
-                "reference": "ba11776e9e6c15ad5759a07bffb15899bac75c2d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/57f1ce82c997f5a8701b89ef970e36bb657fd09c",
+                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c",
                 "shasum": ""
             },
             "require": {
@@ -2831,7 +2903,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T10:59:17+00:00"
+            "time": "2019-02-23T15:06:07+00:00"
         }
     ],
     "aliases": [],

--- a/config/application.php
+++ b/config/application.php
@@ -2,6 +2,7 @@
 
 /* ENVIRONEMENT */
 define('WP_ENV', WP_CUBI_CONFIG['ENVIRONEMENT']);
+define('WP_LOCAL_DEV', WP_ENV === 'development');
 
 /* DATABASE */
 define('DB_NAME', WP_CUBI_CONFIG['DB_NAME']);

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -8,7 +8,8 @@ define('SCRIPT_DEBUG', true);
 define('SAVEQUERIES', PHP_SAPI != 'cli');
 
 /* QUERY MONITOR */
-define('WP_CUBI_QUERY_MONITOR_HANDLE_PHP_ERRORS', false);
+define('QM_DISABLE_ERROR_HANDLER', true);
+define('QM_ENABLE_CAPS_PANEL', true);
 
 /* WONOLOG */
 define('WP_CUBI_LOG_ENABLED', true);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -8,7 +8,8 @@ define('SCRIPT_DEBUG', false);
 define('SAVEQUERIES', false);
 
 /* QUERY MONITOR */
-define('WP_CUBI_QUERY_MONITOR_HANDLE_PHP_ERRORS', true);
+define('QM_DISABLE_ERROR_HANDLER', false);
+define('QM_ENABLE_CAPS_PANEL', false);
 
 /* WONOLOG */
 define('WP_CUBI_LOG_ENABLED', true);

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -8,7 +8,8 @@ define('SCRIPT_DEBUG', false);
 define('SAVEQUERIES', PHP_SAPI != 'cli');
 
 /* QUERY MONITOR */
-define('WP_CUBI_QUERY_MONITOR_HANDLE_PHP_ERRORS', false);
+define('QM_DISABLE_ERROR_HANDLER', true);
+define('QM_ENABLE_CAPS_PANEL', true);
 
 /* WONOLOG */
 define('WP_CUBI_LOG_ENABLED', true);

--- a/config/htaccess/htaccess-performances
+++ b/config/htaccess/htaccess-performances
@@ -118,11 +118,8 @@ FileETag None
 # ----------------------------------------------------------------------
 
 <IfModule mod_headers.c>
-  <FilesMatch "\.(ico|jpe?g|png|gif|swf|css|gz|svg|mp4)$">
+  <FilesMatch "\.(ico|jpe?g|png|gif|swf|js|css|gz|svg|mp4)$">
     Header set Cache-Control "max-age=2592000, public"
-  </FilesMatch>
-  <FilesMatch "\.(js)$">
-    Header set Cache-Control "max-age=2592000, private"
   </FilesMatch>
   <FilesMatch "\.(html|htm)$">
     Header set Cache-Control "max-age=7200, public"

--- a/config/htaccess/htaccess-wp-permalinks
+++ b/config/htaccess/htaccess-wp-permalinks
@@ -6,8 +6,10 @@
 
 <IfModule mod_rewrite.c>
 	RewriteEngine On
+	RewriteRule ^media/ - [L]
 	RewriteBase <##WEB_PATH##>/
 	RewriteRule ^index\.php$ - [L]
+	RewriteCond %{REQUEST_URI} !\.(gif|jpe?g|png|bmp|cur|ico|webp|svgz?|f4a|f4b|m4a|oga|ogg|opus|ogv|mp3|mp4|f4v|f4p|m4v|webm|flv|woff2?|eot|ttc|ttf|otf|css|js|pdf)$ [NC]
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule . <##WEB_PATH##>/index.php [L]

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/20-hooks-query-monitor.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/20-hooks-query-monitor.php
@@ -15,3 +15,16 @@ add_filter('qm/built-in-collectors', function ($collectors) {
     }
     return $collectors;
 });
+
+add_action('wp_head', function () {
+    if (!class_exists(('QM_Dispatchers'))) {
+        return;
+    }
+    if (\QM_Dispatchers::get('html')->user_can_view()) {
+        return;
+    }
+    global $debug_bar;
+    if (isset($debug_bar)) {
+        remove_action('wp_head', [$debug_bar, 'ensure_ajaxurl'], 1);
+    }
+}, 0);

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/20-hooks-query-monitor.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/20-hooks-query-monitor.php
@@ -14,3 +14,17 @@ add_action('wp_head', function () {
         remove_action('wp_head', [$debug_bar, 'ensure_ajaxurl'], 1);
     }
 }, 0);
+
+if (defined('SAVEQUERIES') && !SAVEQUERIES) {
+    add_filter('qm/output/title', function (array $title) {
+        foreach (apply_filters('qm/collect/db_objects', ['$wpdb' => $GLOBALS['wpdb']]) as $key => $db) {
+            $title[] = sprintf(esc_html_x('%s Q', 'Query count', 'query-monitor'), number_format_i18n($db->num_queries));
+        }
+
+        foreach ($title as &$t) {
+            $t = preg_replace('#\s?([^0-9,\.]+)#', '<small>$1</small>', $t);
+        }
+
+        return $title;
+    }, 20);
+}

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/20-hooks-query-monitor.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/20-hooks-query-monitor.php
@@ -2,20 +2,6 @@
 
 namespace Globalis\WP\Cubi;
 
-if (true === WP_CUBI_QUERY_MONITOR_HANDLE_PHP_ERRORS) {
-    return;
-}
-
-add_filter('qm/built-in-collectors', function ($collectors) {
-    foreach ($collectors as $key => $collector_path) {
-        if (str_ends_with($collector_path, 'php_errors.php')) {
-            unset($collectors[$key]);
-            break;
-        }
-    }
-    return $collectors;
-});
-
 add_action('wp_head', function () {
     if (!class_exists(('QM_Dispatchers'))) {
         return;

--- a/web/app/mu-modules/10-wp-cubi-admin-bar/src/AdminBar.php
+++ b/web/app/mu-modules/10-wp-cubi-admin-bar/src/AdminBar.php
@@ -32,7 +32,7 @@ class AdminBar
 
     public function enqueueStyle()
     {
-        if (is_user_logged_in()) {
+        if (is_user_logged_in() && is_admin_bar_showing()) {
             wp_enqueue_style('wp-cubi/admin-bar', plugins_url(self::CSS_PATH, dirname(__FILE__)), [], null);
         }
     }


### PR DESCRIPTION
- Disable query-monitor ensure_ajaxurl when not needed
- Bump wp-cubi-helpers version: 0.3.4
- Update .travis.yml - php 7.3 instead of nightly
- Disable permalinks on static assets (reduce 404's load impact)
- Fix: wp-cubi-admin-bar enqueue style conditions
- query-monitor configuration
- Bump WordPress version: 4.9.10
- Bump composer dependencies
- Fix Cache-Control header on javascript files
- Fix README.md
- Define constant WP_LOCAL_DEV
- Print $wpdb->num_queries in admin-bar / query-monitor when !SAVEQUERIES