### PR TITLE
version 0.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /config/salt-keys.php
 
 # .htaccess
+/config/htaccess/*-local
 /web/.htaccess
 /web/.htpasswd
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "roots/wp-password-bcrypt": "^1.0.0",
         "soberwp/intervention": "^1.2.0",
         "inpsyde/wonolog": "^1.0.2",
-        "wpackagist-plugin/query-monitor": "^3.3.4",
+        "wpackagist-plugin/query-monitor": "^3.3.5",
         "wpackagist-plugin/wp-crontrol": "^1.7.1",
         "wpackagist-plugin/user-switching": "^1.5.0",
         "wpackagist-plugin/autodescription": "^3.2.4"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=7.0",
         "composer/installers": "^1.5.0",
         "johnpbloch/wordpress-core-installer": "^1.0",
-        "johnpbloch/wordpress-core": "5.1.1",
+        "johnpbloch/wordpress-core": "5.2.0",
         "globalis/wp-cli-bin" : "^2.2.0",
         "globalis/wp-cubi-helpers": "^0.3.5",
         "globalis/wp-cubi-imagemin": "^1.0.5",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "johnpbloch/wordpress-core": "5.2.1",
         "globalis/wp-cli-bin" : "^2.2.0",
         "globalis/wp-cubi-helpers": "^0.3.5",
-        "globalis/wp-cubi-imagemin": "^1.0.5",
+        "globalis/wp-cubi-imagemin": "^1.1.0",
         "roots/soil": "^3.7.3",
         "roots/wp-password-bcrypt": "^1.0.0",
         "soberwp/intervention": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "wpackagist-plugin/autodescription": "^3.2.4"
     },
     "require-dev": {
-        "globalis/wp-cubi-robo" : "^0.1.6",
+        "globalis/wp-cubi-robo" : "^0.1.7",
         "squizlabs/php_codesniffer": "^2.9.2"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "composer/installers": "^1.5.0",
         "johnpbloch/wordpress-core-installer": "^1.0",
         "johnpbloch/wordpress-core": "5.1.1",
-        "globalis/wp-cli-bin" : "^2.1.0",
+        "globalis/wp-cli-bin" : "^2.2.0",
         "globalis/wp-cubi-helpers": "^0.3.5",
         "globalis/wp-cubi-imagemin": "^1.0.5",
         "roots/soil": "^3.7.3",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "roots/wp-password-bcrypt": "^1.0.0",
         "soberwp/intervention": "^1.2.0",
         "inpsyde/wonolog": "^1.0.2",
-        "wpackagist-plugin/query-monitor": "^3.3.5",
+        "wpackagist-plugin/query-monitor": "^3.3.6",
         "wpackagist-plugin/wp-crontrol": "^1.7.1",
         "wpackagist-plugin/user-switching": "^1.5.0",
         "wpackagist-plugin/autodescription": "^3.2.4"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=7.0",
         "composer/installers": "^1.5.0",
         "johnpbloch/wordpress-core-installer": "^1.0",
-        "johnpbloch/wordpress-core": "5.2.0",
+        "johnpbloch/wordpress-core": "5.2.1",
         "globalis/wp-cli-bin" : "^2.2.0",
         "globalis/wp-cubi-helpers": "^0.3.5",
         "globalis/wp-cubi-imagemin": "^1.0.5",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "soberwp/intervention": "^1.2.0",
         "inpsyde/wonolog": "^1.0.2",
         "wpackagist-plugin/query-monitor": "^3.3.4",
-        "wpackagist-plugin/wp-crontrol": "^1.7.0",
+        "wpackagist-plugin/wp-crontrol": "^1.7.1",
         "wpackagist-plugin/user-switching": "^1.5.0",
         "wpackagist-plugin/autodescription": "^3.2.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -873,15 +873,15 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "3.3.5",
+            "version": "3.3.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.3.5"
+                "reference": "tags/3.3.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.3.5.zip",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.3.6.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7662891af463621e30db8dec6ffaf83f",
+    "content-hash": "23c6b933a96ee91ebfb0b260df5e0e45",
     "packages": [
         {
             "name": "composer/installers",
@@ -228,22 +228,23 @@
         },
         {
             "name": "globalis/wp-cubi-imagemin",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/globalis-ms/wp-cubi-imagemin.git",
-                "reference": "31e1a138fe4c28d2ca6e8b7fc3156a3ce149d8ba"
+                "reference": "1269ed20df52e179d9ce92eeb470981ca2d96aff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/globalis-ms/wp-cubi-imagemin/zipball/31e1a138fe4c28d2ca6e8b7fc3156a3ce149d8ba",
-                "reference": "31e1a138fe4c28d2ca6e8b7fc3156a3ce149d8ba",
+                "url": "https://api.github.com/repos/globalis-ms/wp-cubi-imagemin/zipball/1269ed20df52e179d9ce92eeb470981ca2d96aff",
+                "reference": "1269ed20df52e179d9ce92eeb470981ca2d96aff",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "^1.5.0",
                 "php": ">=5.5.0",
-                "ps/image-optimizer": "^1.2.0"
+                "ps/image-optimizer": "^1.2.0",
+                "psr/log": "^1.0"
             },
             "require-dev": {
                 "squizlabs/php_codesniffer": "^2.5.1"
@@ -265,7 +266,7 @@
             ],
             "description": "Standalone image minification WordPress plugin",
             "homepage": "https://github.com/globalis-ms/wp-cubi-imagemin",
-            "time": "2019-04-05T10:12:28+00:00"
+            "time": "2019-05-22T14:43:23+00:00"
         },
         {
             "name": "inpsyde/wonolog",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "20f00a90667f4c2716f2fc68b1913e58",
+    "content-hash": "b937a3b4eb3db83752c7db6e186d9ca7",
     "packages": [
         {
             "name": "composer/installers",
@@ -336,23 +336,23 @@
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.1.1",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "dba22982e7cb433b68f1b12a0bd4e5851f967010"
+                "reference": "9d9c5f36166e7d31f1c90784e71dad3996d28a95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/dba22982e7cb433b68f1b12a0bd4e5851f967010",
-                "reference": "dba22982e7cb433b68f1b12a0bd4e5851f967010",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/9d9c5f36166e7d31f1c90784e71dad3996d28a95",
+                "reference": "9d9c5f36166e7d31f1c90784e71dad3996d28a95",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "5.1.1"
+                "wordpress/core-implementation": "5.2.0"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -365,14 +365,14 @@
                     "homepage": "http://wordpress.org/about/"
                 }
             ],
-            "description": "WordPress is web software you can use to create a beautiful website or blog.",
+            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
             "homepage": "http://wordpress.org/",
             "keywords": [
                 "blog",
                 "cms",
                 "wordpress"
             ],
-            "time": "2019-03-13T00:27:30+00:00"
+            "time": "2019-05-07T20:42:17+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9443087ebff8a993f3a55ce9304f113c",
+    "content-hash": "20f00a90667f4c2716f2fc68b1913e58",
     "packages": [
         {
             "name": "composer/installers",
@@ -128,16 +128,16 @@
         },
         {
             "name": "globalis/wp-cli-bin",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/globalis-ms/wp-cli-bin.git",
-                "reference": "a27e3bbffc8fbb11b683ee65ebf670c09eed649d"
+                "reference": "da0046dbf7b2582710726d27ecc75b256eea154b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/globalis-ms/wp-cli-bin/zipball/a27e3bbffc8fbb11b683ee65ebf670c09eed649d",
-                "reference": "a27e3bbffc8fbb11b683ee65ebf670c09eed649d",
+                "url": "https://api.github.com/repos/globalis-ms/wp-cli-bin/zipball/da0046dbf7b2582710726d27ecc75b256eea154b",
+                "reference": "da0046dbf7b2582710726d27ecc75b256eea154b",
                 "shasum": ""
             },
             "bin": [
@@ -163,7 +163,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2019-02-06T15:20:49+00:00"
+            "time": "2019-04-26T10:23:45+00:00"
         },
         {
             "name": "globalis/wp-cubi-helpers",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1718016189202d01eb6f3527b88a4ef1",
+    "content-hash": "bbe7970c5902f6aa4b59ecea95c1572b",
     "packages": [
         {
             "name": "composer/installers",
@@ -873,15 +873,15 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "3.3.4",
+            "version": "3.3.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.3.4"
+                "reference": "tags/3.3.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.3.4.zip",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.3.5.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b937a3b4eb3db83752c7db6e186d9ca7",
+    "content-hash": "1718016189202d01eb6f3527b88a4ef1",
     "packages": [
         {
             "name": "composer/installers",
@@ -913,15 +913,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-crontrol",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-crontrol/",
-                "reference": "tags/1.7.0"
+                "reference": "tags/1.7.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.7.0.zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.7.1.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbe7970c5902f6aa4b59ecea95c1572b",
+    "content-hash": "7662891af463621e30db8dec6ffaf83f",
     "packages": [
         {
             "name": "composer/installers",
@@ -336,23 +336,23 @@
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.2.0",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "9d9c5f36166e7d31f1c90784e71dad3996d28a95"
+                "reference": "7555561027211f295e1d6a77d06ab47f605608cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/9d9c5f36166e7d31f1c90784e71dad3996d28a95",
-                "reference": "9d9c5f36166e7d31f1c90784e71dad3996d28a95",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/7555561027211f295e1d6a77d06ab47f605608cd",
+                "reference": "7555561027211f295e1d6a77d06ab47f605608cd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "5.2.0"
+                "wordpress/core-implementation": "5.2.1"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -372,7 +372,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2019-05-07T20:42:17+00:00"
+            "time": "2019-05-21T18:27:33+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ec13eb1ba844dc77b757e3860b86016",
+    "content-hash": "9443087ebff8a993f3a55ce9304f113c",
     "packages": [
         {
             "name": "composer/installers",
@@ -1900,16 +1900,16 @@
         },
         {
             "name": "globalis/wp-cubi-robo",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/globalis-ms/wp-cubi-robo.git",
-                "reference": "1d7794488232a910725340ecd386303f126e764f"
+                "reference": "4acc9d37c77e24a968a950d59b5ba53818c53bc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/globalis-ms/wp-cubi-robo/zipball/1d7794488232a910725340ecd386303f126e764f",
-                "reference": "1d7794488232a910725340ecd386303f126e764f",
+                "url": "https://api.github.com/repos/globalis-ms/wp-cubi-robo/zipball/4acc9d37c77e24a968a950d59b5ba53818c53bc1",
+                "reference": "4acc9d37c77e24a968a950d59b5ba53818c53bc1",
                 "shasum": ""
             },
             "require": {
@@ -1941,7 +1941,7 @@
             ],
             "description": "Default Robo commands for wp-cubi",
             "homepage": "https://github.com/globalis-ms/wp-cubi-robo",
-            "time": "2019-04-05T09:14:56+00:00"
+            "time": "2019-04-25T15:47:31+00:00"
         },
         {
             "name": "grasmash/expander",

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -14,7 +14,7 @@ define('QM_ENABLE_CAPS_PANEL', false);
 
 /* WONOLOG */
 define('WP_CUBI_LOG_ENABLED', true);
-define('WP_CUBI_LOG_LEVEL', 'DEBUG');
+define('WP_CUBI_LOG_LEVEL', 'INFO');
 define('WP_CUBI_LOG_PHP_ERRORS', true);
 
 /* MEMORY */

--- a/web/app/mu-modules/00-wp-cubi-core-mu/00-wp-cubi-core-mu.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/00-wp-cubi-core-mu.php
@@ -53,3 +53,6 @@ require_once __DIR__ . '/src/30-disable-useless-sql-queries.php';
 
 // Disable version update checks
 require_once __DIR__ . '/src/30-disable-version-update-checks.php';
+
+// jQuery (frontend): use cdnjs.cloudflare.com
+require_once __DIR__ . '/src/40-jquery-cdn.php';

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/20-clean-wp-admin.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/20-clean-wp-admin.php
@@ -12,15 +12,6 @@ if (is_blog_admin() && !empty($_SERVER['HTTP_USER_AGENT'])) {
 }
 
 /*
- * Disable dashboard php version widget (avoid unecessary SQL queries and HTTP requests)
- */
-if (is_blog_admin()) {
-    add_filter('pre_site_transient_php_check_' . md5(phpversion()), function ($default) {
-        return ['is_acceptable' => true];
-    });
-}
-
-/*
  * @see https://github.com/soberwp/intervention/
  */
 add_action('plugins_loaded', function () {

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/20-soil-modules.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/20-soil-modules.php
@@ -7,7 +7,6 @@ add_action('after_setup_theme', function () {
     add_theme_support('soil-clean-up');
     add_theme_support('soil-nice-search');
     add_theme_support('soil-disable-trackbacks');
-    add_theme_support('soil-jquery-cdn');
     //add_theme_support('soil-disable-asset-versioning');
     //add_theme_support('soil-js-to-footer');
     //add_theme_support('soil-nav-walker');

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/20-wp-login.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/20-wp-login.php
@@ -17,6 +17,6 @@ add_filter('login_headerurl', function ($url) {
     return esc_url(home_url('/'));
 }, 10, 1);
 
-add_filter('login_headertitle', function ($title) {
+add_filter('login_headertext', function ($title) {
      return get_bloginfo('name');
 }, 10, 1);

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
@@ -22,7 +22,7 @@ function jquery_url()
 function jquery_domain()
 {
     $parts = parse_url(jquery_url());
- 
+
     if (is_array($parts) && !empty($parts['host'])) {
         return $parts['host'];
     }

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
@@ -36,6 +36,8 @@ function register_jquery()
 
     wp_register_script('jquery', jquery_url(), [], null, true);
 
+    wp_add_inline_script('jquery', 'jQuery.noConflict();', 'after');
+
     add_filter('wp_resource_hints', function ($urls, $relation_type) {
         if ($relation_type === 'dns-prefetch' && $jquery_domain = jquery_domain()) {
             $urls[] = $jquery_domain;

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Globalis\WP\Cubi;
+
+if (!defined('WP_CUBI_JQUERY_VERSION')) {
+    define('WP_CUBI_JQUERY_VERSION', '3.4.0');
+}
+
+if (!defined('WP_CUBI_JQUERY_CDN_URL')) {
+    define('WP_CUBI_JQUERY_CDN_URL', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/%s/jquery.min.js');
+    // define('WP_CUBI_JQUERY_CDN_URL', 'https://ajax.googleapis.com/ajax/libs/jquery/%s/jquery.min.js');
+    // define('WP_CUBI_JQUERY_CDN_URL', 'https://code.jquery.com/jquery-%s.min.js');
+}
+
+add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\register_jquery', 200);
+
+function jquery_url()
+{
+    return sprintf(WP_CUBI_JQUERY_CDN_URL, WP_CUBI_JQUERY_VERSION);
+}
+
+function jquery_domain()
+{
+    $parts = parse_url(jquery_url());
+ 
+    if (is_array($parts) && !empty($parts['host'])) {
+        return $parts['host'];
+    }
+
+    return false;
+}
+
+function register_jquery()
+{
+    wp_deregister_script('jquery');
+
+    wp_register_script('jquery', jquery_url(), [], null, true);
+
+    add_filter('wp_resource_hints', function ($urls, $relation_type) {
+        if ($relation_type === 'dns-prefetch' && $jquery_domain = jquery_domain()) {
+            $urls[] = $jquery_domain;
+        }
+        return $urls;
+    }, 10, 2);
+}

--- a/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
+++ b/web/app/mu-modules/00-wp-cubi-core-mu/src/40-jquery-cdn.php
@@ -13,6 +13,7 @@ if (!defined('WP_CUBI_JQUERY_CDN_URL')) {
 }
 
 add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\register_jquery', 200);
+add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\jquery_dns_prefetch', 999);
 
 function jquery_url()
 {
@@ -37,6 +38,13 @@ function register_jquery()
     wp_register_script('jquery', jquery_url(), [], null, true);
 
     wp_add_inline_script('jquery', 'jQuery.noConflict();', 'after');
+}
+
+function jquery_dns_prefetch()
+{
+    if (!wp_script_is('jquery', 'enqueued')) {
+        return;
+    }
 
     add_filter('wp_resource_hints', function ($urls, $relation_type) {
         if ($relation_type === 'dns-prefetch' && $jquery_domain = jquery_domain()) {


### PR DESCRIPTION
- jquery-cdn : use cdnjs.cloudflare.com instead of code.jquery.com
- wp-cubi-imagemin: log errors through wonolog
- WordPress version: 5.2.1
- wp-cli version: 2.2.0
- Bump WordPress plugins versions